### PR TITLE
Improve calls of ripgrep and fzf

### DIFF
--- a/.cdprc
+++ b/.cdprc
@@ -49,8 +49,8 @@ unset FZFPOS
 
 # Since arrays are not exportable(!?) as required for __list_files_with_status
 # a normal variable is used for that:
-unset RG_OPTIONS
-export RG_OPTIONS="--type=markdown --no-ignore-parent"
+unset RG
+export RG="rg --type=markdown --no-ignore-parent"
 
 edit_translate_by_status() {
     if command -pv fzf >/dev/null ; then
@@ -58,7 +58,7 @@ edit_translate_by_status() {
             TMPFILE=$( mktemp tmp.XXXXXXXX )
             FILE=$(cd de/src || exit
                    # shellcheck disable=2086  # to get the RG_OPTION word-splitted
-                   rg ${RG_OPTIONS} --files-with-matches "$1" \
+                   ${RG} --files-with-matches "$1" \
                    | sort | tee "../../${TMPFILE}" \
                    | fzf --reverse --exact \
                          --bind="load:pos($FZFPOS)" \
@@ -77,12 +77,12 @@ edit_translate_by_status() {
     else
         (cd de/src || exit
          # shellcheck disable=2086  # to get the RG_OPTION word-splitted
-         rg ${RG_OPTIONS} --files-with-matches "$1" \
+         ${RG} --files-with-matches "$1" \
          | sort)
         read -r -p "Continue? ENTER, or Ctrl-C to cancel: " inp
         for FILE in $(cd de/src || exit
                       # shellcheck disable=2086  # to get the RG_OPTION word-splitted
-                      rg ${RG_OPTIONS} --files-with-matches "$1" \
+                      ${RG} --files-with-matches "$1" \
                       | sort)
         do
             ${EDIT_IN_SPLIT_WINDOWS} {de,en}/src/"$FILE"
@@ -130,10 +130,10 @@ __list_files_with_status() {
     V=$(__get_escaped_status "$1" )
     if [ "${V}" == " --NO-STATUS--" ] ; then
         # shellcheck disable=2086  # to get the RG_OPTION word-splitted
-        rg ${RG_OPTIONS} --ignore-file=.rgignore_cdprc --files-without-match "^\[\.status\]:" | sort
+        ${RG} --ignore-file=.rgignore_cdprc --files-without-match "^\[\.status\]:" | sort
     else
         # shellcheck disable=2086  # to get the RG_OPTION word-splitted
-        rg ${RG_OPTIONS} --ignore-file=.rgignore_cdprc --files-with-matches  "^\[\.status\]:${V}$" | sort
+        ${RG} --ignore-file=.rgignore_cdprc --files-with-matches  "^\[\.status\]:${V}$" | sort
     fi
 }
 
@@ -149,10 +149,10 @@ edit_by_status() {
             __list_files_with_status " rft"
             echo "... but not in the preview function below! :-("
             # shellcheck disable=2086  # to get the RG_OPTION word-splitted
-            WITHOUT_STATUS=$(rg ${RG_OPTIONS} --ignore-file=.rgignore_cdprc --files-without-match "^\[\.status\]:" | wc -l)
+            WITHOUT_STATUS=$(${RG} --ignore-file=.rgignore_cdprc --files-without-match "^\[\.status\]:" | wc -l)
             # shellcheck disable=2016,2086  # Expressions don't expand in single quotes, use double quotes for that.
             # Because that string is passed to fzf's preview option!
-            STATUS=$( (rg ${RG_OPTIONS} --ignore-file=.rgignore_cdprc --no-filename "^\[\.status\]:" \
+            STATUS=$( (${RG} --ignore-file=.rgignore_cdprc --no-filename "^\[\.status\]:" \
                        | sort | uniq -c
                        printf "%7d %s" "${WITHOUT_STATUS}" "[]: --NO-STATUS--") \
                       | fzf --reverse --select-1 --exact \
@@ -164,7 +164,7 @@ edit_by_status() {
                 TMPFILE=$( mktemp tmp.XXXXXXXX )
                 if [ "${VALUE}" == " --NO-STATUS--" ] ; then
                     # shellcheck disable=2086  # to get the RG_OPTION word-splitted
-                    mapfile -t FILES < <(rg ${RG_OPTIONS} --ignore-file=.rgignore_cdprc --files-without-match "^\[\.status\]:" \
+                    mapfile -t FILES < <(${RG} --ignore-file=.rgignore_cdprc --files-without-match "^\[\.status\]:" \
                                          | sort | tee "${TMPFILE}" \
                                          | fzf --reverse --exact --multi --bind alt-a:select-all,alt-d:deselect-all \
                                                --bind="load:pos($FZFPOS)" \
@@ -177,7 +177,7 @@ edit_by_status() {
                     # But shellcheck complained with SC2207...  https://www.shellcheck.net/wiki/SC2207
                     # And so it is now:
                     # shellcheck disable=2086  # to get the RG_OPTION word-splitted
-                    mapfile -t FILES < <(rg ${RG_OPTIONS} --ignore-file=.rgignore_cdprc --files-with-matches "^\[\.status\]:${VALUE}$"\
+                    mapfile -t FILES < <(${RG} --ignore-file=.rgignore_cdprc --files-with-matches "^\[\.status\]:${VALUE}$"\
                                          | sort | tee "${TMPFILE}" \
                                          | fzf --reverse --exact --multi --bind alt-a:select-all,alt-d:deselect-all \
                                                --bind="load:pos($FZFPOS)" \

--- a/.cdprc
+++ b/.cdprc
@@ -47,7 +47,10 @@ fi
 echo -e "\n*** Define helpful functions and aliases:\n"
 unset FZFPOS
 
-export RG_OPTIONS=(--type=markdown --no-ignore-parent)
+RG_OPTIONS=(--type=markdown --no-ignore-parent)
+# Since arrays are not exportable(!?) as required for __list_files_with_status
+# a normal variable is used for that:
+export RG_OPTIONS2="${RG_OPTIONS[*]}"
 
 edit_translate_by_status() {
     if command -pv fzf >/dev/null ; then
@@ -123,11 +126,11 @@ __get_escaped_status () {
 __list_files_with_status() {
     V=$(__get_escaped_status "$1" )
     if [ "${V}" == " --NO-STATUS--" ] ; then
-            set -x
-        rg "${RG_OPTIONS[@]}" --ignore-file=.rgignore_cdprc --files-without-match "^\[\.status\]:" | sort
-            set +x
+        # shellcheck disable=2086
+        rg ${RG_OPTIONS2} --ignore-file=.rgignore_cdprc --files-without-match "^\[\.status\]:" | sort
     else
-        rg "${RG_OPTIONS[@]}" --ignore-file=.rgignore_cdprc --files-with-matches  "^\[\.status\]:${V}$" | sort
+        # shellcheck disable=2086
+        rg ${RG_OPTIONS2} --ignore-file=.rgignore_cdprc --files-with-matches  "^\[\.status\]:${V}$" | sort
     fi
 }
 
@@ -139,7 +142,9 @@ edit_by_status() {
     if command -pv fzf >/dev/null ; then
         while true; do
             shopt -s extglob               # disabled by default
-
+            echo "here it's working..."
+            __list_files_with_status " rft"
+            echo "... but not in the preview function below! :-("
             WITHOUT_STATUS=$(rg "${RG_OPTIONS[@]}" --ignore-file=.rgignore_cdprc --files-without-match "^\[\.status\]:" | wc -l)
             # shellcheck disable=2016  # Expressions don't expand in single quotes, use double quotes for that.
             # Because that string is passed to fzf's preview option!

--- a/.cdprc
+++ b/.cdprc
@@ -44,13 +44,18 @@ if [[ "$FZF_VERSION" < "0.36.0" ]] ; then
     return 1
 fi
 
-echo -e "\n*** Define helpful functions and aliases:\n"
 unset FZFPOS
 
 # Since arrays are not exportable(!?) as required for __list_files_with_status
 # a normal variable is used for that:
 unset RG
 export RG="rg --type=markdown --no-ignore-parent"
+
+FZF=(fzf --reverse --exact)
+# shellcheck disable=2054
+FZF_MULTI=("${FZF[@]}" --multi --bind alt-a:select-all,alt-d:deselect-all --preview='cat {}')
+
+echo -e "\n*** Define helpful functions and aliases:\n"
 
 edit_translate_by_status() {
     if command -pv fzf >/dev/null ; then
@@ -60,9 +65,10 @@ edit_translate_by_status() {
                    # shellcheck disable=2086  # to get the RG_OPTION word-splitted
                    ${RG} --files-with-matches "$1" \
                    | sort | tee "../../${TMPFILE}" \
-                   | fzf --reverse --exact \
-                         --bind="load:pos($FZFPOS)" \
-                         --preview='cat {}' --header="$FZF_HEADER")
+                   | "${FZF[@]}" \
+                        --header="$FZF_HEADER" \
+                        --bind="load:pos($FZFPOS)" \
+                        --preview='cat {}')
             [ -z "$FILE" ] && break
             unset FZFPOS
             # remember position of selected entry to be able to re-position fzf to it
@@ -144,10 +150,8 @@ export -f __list_files_with_status __get_escaped_status
 edit_by_status() {
     if command -pv fzf >/dev/null ; then
         while true; do
+            FZF_HEADER=">> Please select status and press ENTER to list and edit corresponding files. (ESC to cancel.) <<"
             shopt -s extglob               # disabled by default
-            echo "here it's working..."
-            __list_files_with_status " rft"
-            echo "... but not in the preview function below! :-("
             # shellcheck disable=2086  # to get the RG_OPTION word-splitted
             WITHOUT_STATUS=$(${RG} --ignore-file=.rgignore_cdprc --files-without-match "^\[\.status\]:" | wc -l)
             # shellcheck disable=2016,2086  # Expressions don't expand in single quotes, use double quotes for that.
@@ -155,21 +159,23 @@ edit_by_status() {
             STATUS=$( (${RG} --ignore-file=.rgignore_cdprc --no-filename "^\[\.status\]:" \
                        | sort | uniq -c
                        printf "%7d %s" "${WITHOUT_STATUS}" "[]: --NO-STATUS--") \
-                      | fzf --reverse --select-1 --exact \
-                            --preview='V={}; __list_files_with_status "$V"' \
-                            --header=">> Please select status and press ENTER to list and edit corresponding files. (ESC to cancel.) <<")
+                      | "${FZF[@]}" \
+                           --header="${FZF_HEADER}" \
+                           --select-1 \
+                           --preview='V={}; __list_files_with_status "$V"')
             [ -z "$STATUS" ] && break
+
             VALUE=$( get_escaped_status "$STATUS" )
+            FZF_HEADER=">> Please select file(s) to edit and press ENTER. (ESC to cancel.) <<"
             while true; do
                 TMPFILE=$( mktemp tmp.XXXXXXXX )
                 if [ "${VALUE}" == " --NO-STATUS--" ] ; then
                     # shellcheck disable=2086  # to get the RG_OPTION word-splitted
                     mapfile -t FILES < <(${RG} --ignore-file=.rgignore_cdprc --files-without-match "^\[\.status\]:" \
                                          | sort | tee "${TMPFILE}" \
-                                         | fzf --reverse --exact --multi --bind alt-a:select-all,alt-d:deselect-all \
-                                               --bind="load:pos($FZFPOS)" \
-                                               --preview='cat {}' \
-                                               --header=">> Please select file(s) to edit and press ENTER. (ESC to cancel.) <<")
+                                         | "${FZF_MULTI[@]}" \
+                                              --header="${FZF_HEADER}" \
+                                              --bind="load:pos($FZFPOS)")
                 else
                     # Solutions for opening multiple file found here:
                     # https://github-wiki-see.page/m/junegunn/fzf/wiki/examples (Section "Opening files")
@@ -179,10 +185,9 @@ edit_by_status() {
                     # shellcheck disable=2086  # to get the RG_OPTION word-splitted
                     mapfile -t FILES < <(${RG} --ignore-file=.rgignore_cdprc --files-with-matches "^\[\.status\]:${VALUE}$"\
                                          | sort | tee "${TMPFILE}" \
-                                         | fzf --reverse --exact --multi --bind alt-a:select-all,alt-d:deselect-all \
-                                               --bind="load:pos($FZFPOS)" \
-                                               --preview='cat {}' \
-                                               --header=">> Please select file(s) to edit and press ENTER. (ESC to cancel.) <<")
+                                         | "${FZF_MULTI[@]}" \
+                                              --header="${FZF_HEADER}" \
+                                              --bind="load:pos($FZFPOS)")
                 fi
                 [[ "${FILES[*]}" ]] || break
                 unset FZFPOS

--- a/.cdprc
+++ b/.cdprc
@@ -47,17 +47,18 @@ fi
 echo -e "\n*** Define helpful functions and aliases:\n"
 unset FZFPOS
 
-RG_OPTIONS=(--type=markdown --no-ignore-parent)
 # Since arrays are not exportable(!?) as required for __list_files_with_status
 # a normal variable is used for that:
-export RG_OPTIONS2="${RG_OPTIONS[*]}"
+unset RG_OPTIONS
+export RG_OPTIONS="--type=markdown --no-ignore-parent"
 
 edit_translate_by_status() {
     if command -pv fzf >/dev/null ; then
         while true; do
             TMPFILE=$( mktemp tmp.XXXXXXXX )
             FILE=$(cd de/src || exit
-                   rg "${RG_OPTIONS[@]}" --files-with-matches "$1" \
+                   # shellcheck disable=2086  # to get the RG_OPTION word-splitted
+                   rg ${RG_OPTIONS} --files-with-matches "$1" \
                    | sort | tee "../../${TMPFILE}" \
                    | fzf --reverse --exact \
                          --bind="load:pos($FZFPOS)" \
@@ -75,11 +76,13 @@ edit_translate_by_status() {
         unset FZFPOS
     else
         (cd de/src || exit
-         rg "${RG_OPTIONS[@]}" --files-with-matches "$1" \
+         # shellcheck disable=2086  # to get the RG_OPTION word-splitted
+         rg ${RG_OPTIONS} --files-with-matches "$1" \
          | sort)
         read -r -p "Continue? ENTER, or Ctrl-C to cancel: " inp
         for FILE in $(cd de/src || exit
-                      rg "${RG_OPTIONS[@]}" --files-with-matches "$1" \
+                      # shellcheck disable=2086  # to get the RG_OPTION word-splitted
+                      rg ${RG_OPTIONS} --files-with-matches "$1" \
                       | sort)
         do
             ${EDIT_IN_SPLIT_WINDOWS} {de,en}/src/"$FILE"
@@ -126,11 +129,11 @@ __get_escaped_status () {
 __list_files_with_status() {
     V=$(__get_escaped_status "$1" )
     if [ "${V}" == " --NO-STATUS--" ] ; then
-        # shellcheck disable=2086
-        rg ${RG_OPTIONS2} --ignore-file=.rgignore_cdprc --files-without-match "^\[\.status\]:" | sort
+        # shellcheck disable=2086  # to get the RG_OPTION word-splitted
+        rg ${RG_OPTIONS} --ignore-file=.rgignore_cdprc --files-without-match "^\[\.status\]:" | sort
     else
-        # shellcheck disable=2086
-        rg ${RG_OPTIONS2} --ignore-file=.rgignore_cdprc --files-with-matches  "^\[\.status\]:${V}$" | sort
+        # shellcheck disable=2086  # to get the RG_OPTION word-splitted
+        rg ${RG_OPTIONS} --ignore-file=.rgignore_cdprc --files-with-matches  "^\[\.status\]:${V}$" | sort
     fi
 }
 
@@ -145,10 +148,11 @@ edit_by_status() {
             echo "here it's working..."
             __list_files_with_status " rft"
             echo "... but not in the preview function below! :-("
-            WITHOUT_STATUS=$(rg "${RG_OPTIONS[@]}" --ignore-file=.rgignore_cdprc --files-without-match "^\[\.status\]:" | wc -l)
-            # shellcheck disable=2016  # Expressions don't expand in single quotes, use double quotes for that.
+            # shellcheck disable=2086  # to get the RG_OPTION word-splitted
+            WITHOUT_STATUS=$(rg ${RG_OPTIONS} --ignore-file=.rgignore_cdprc --files-without-match "^\[\.status\]:" | wc -l)
+            # shellcheck disable=2016,2086  # Expressions don't expand in single quotes, use double quotes for that.
             # Because that string is passed to fzf's preview option!
-            STATUS=$( (rg "${RG_OPTIONS[@]}" --ignore-file=.rgignore_cdprc --no-filename "^\[\.status\]:" \
+            STATUS=$( (rg ${RG_OPTIONS} --ignore-file=.rgignore_cdprc --no-filename "^\[\.status\]:" \
                        | sort | uniq -c
                        printf "%7d %s" "${WITHOUT_STATUS}" "[]: --NO-STATUS--") \
                       | fzf --reverse --select-1 --exact \
@@ -159,7 +163,8 @@ edit_by_status() {
             while true; do
                 TMPFILE=$( mktemp tmp.XXXXXXXX )
                 if [ "${VALUE}" == " --NO-STATUS--" ] ; then
-                    mapfile -t FILES < <(rg "${RG_OPTIONS[@]}" --ignore-file=.rgignore_cdprc --files-without-match "^\[\.status\]:" \
+                    # shellcheck disable=2086  # to get the RG_OPTION word-splitted
+                    mapfile -t FILES < <(rg ${RG_OPTIONS} --ignore-file=.rgignore_cdprc --files-without-match "^\[\.status\]:" \
                                          | sort | tee "${TMPFILE}" \
                                          | fzf --reverse --exact --multi --bind alt-a:select-all,alt-d:deselect-all \
                                                --bind="load:pos($FZFPOS)" \
@@ -171,7 +176,8 @@ edit_by_status() {
                     # Otherwise the LFs aren't interpreted correctly by the editor.
                     # But shellcheck complained with SC2207...  https://www.shellcheck.net/wiki/SC2207
                     # And so it is now:
-                    mapfile -t FILES < <(rg "${RG_OPTIONS[@]}" --ignore-file=.rgignore_cdprc --files-with-matches "^\[\.status\]:${VALUE}$"\
+                    # shellcheck disable=2086  # to get the RG_OPTION word-splitted
+                    mapfile -t FILES < <(rg ${RG_OPTIONS} --ignore-file=.rgignore_cdprc --files-with-matches "^\[\.status\]:${VALUE}$"\
                                          | sort | tee "${TMPFILE}" \
                                          | fzf --reverse --exact --multi --bind alt-a:select-all,alt-d:deselect-all \
                                                --bind="load:pos($FZFPOS)" \

--- a/.cdprc
+++ b/.cdprc
@@ -37,21 +37,24 @@ fi
 
 FZF_VERSION=$(fzf --version | awk '{print $1}')
 if [[ "$FZF_VERSION" < "0.36.0" ]] ; then
-    echo "Problem: The installed program 'fzf' ${FZF_VERSION} is too old. At least version 0.36.0 is required."
-    echo "         If your distro doesn't provide a recent version you might want to look at"
-    echo "         https://github.com/junegunn/fzf/releases  for binary releases."
+    echo "Problem: The installed program 'fzf' ${FZF_VERSION} is too old."
+    echo "At least version 0.36.0 is required."
+    echo "If your distro doesn't provide a recent version you might want to look at"
+    echo "https://github.com/junegunn/fzf/releases  for binary releases."
     return 1
 fi
 
 echo -e "\n*** Define helpful functions and aliases:\n"
 unset FZFPOS
 
+export RG_OPTIONS=(--type=markdown --no-ignore-parent)
+
 edit_translate_by_status() {
     if command -pv fzf >/dev/null ; then
         while true; do
             TMPFILE=$( mktemp tmp.XXXXXXXX )
             FILE=$(cd de/src || exit
-                   rg --type=markdown --no-ignore-parent --files-with-matches "$1" \
+                   rg "${RG_OPTIONS[@]}" --files-with-matches "$1" \
                    | sort | tee "../../${TMPFILE}" \
                    | fzf --reverse --exact \
                          --bind="load:pos($FZFPOS)" \
@@ -69,11 +72,11 @@ edit_translate_by_status() {
         unset FZFPOS
     else
         (cd de/src || exit
-         rg --type=markdown --no-ignore-parent --files-with-matches "$1" \
+         rg "${RG_OPTIONS[@]}" --files-with-matches "$1" \
          | sort)
         read -r -p "Continue? ENTER, or Ctrl-C to cancel: " inp
         for FILE in $(cd de/src || exit
-                      rg --type=markdown --no-ignore-parent --files-with-matches "$1" \
+                      rg "${RG_OPTIONS[@]}" --files-with-matches "$1" \
                       | sort)
         do
             ${EDIT_IN_SPLIT_WINDOWS} {de,en}/src/"$FILE"
@@ -119,25 +122,28 @@ __get_escaped_status () {
 
 __list_files_with_status() {
     V=$(__get_escaped_status "$1" )
-    (if [ "${V}" == " --NO-STATUS--" ] ; then
-        rg --type=markdown --no-ignore-parent --ignore-file=.rgignore_cdprc --files-without-match "^\[\.status\]:"
+    if [ "${V}" == " --NO-STATUS--" ] ; then
+            set -x
+        rg "${RG_OPTIONS[@]}" --ignore-file=.rgignore_cdprc --files-without-match "^\[\.status\]:" | sort
+            set +x
     else
-        rg --type=markdown --no-ignore-parent --ignore-file=.rgignore_cdprc --files-with-matches  "^\[\.status\]:${V}$"
-    fi) | sort
+        rg "${RG_OPTIONS[@]}" --ignore-file=.rgignore_cdprc --files-with-matches  "^\[\.status\]:${V}$" | sort
+    fi
 }
 
 export -f __list_files_with_status __get_escaped_status
 # ------------------------------------------------------------------------
+
 
 edit_by_status() {
     if command -pv fzf >/dev/null ; then
         while true; do
             shopt -s extglob               # disabled by default
 
-            WITHOUT_STATUS=$(rg --type=markdown --no-ignore-parent --ignore-file=.rgignore_cdprc --files-without-match "^\[\.status\]:" | wc -l)
+            WITHOUT_STATUS=$(rg "${RG_OPTIONS[@]}" --ignore-file=.rgignore_cdprc --files-without-match "^\[\.status\]:" | wc -l)
             # shellcheck disable=2016  # Expressions don't expand in single quotes, use double quotes for that.
             # Because that string is passed to fzf's preview option!
-            STATUS=$( (rg --type=markdown --no-ignore-parent --ignore-file=.rgignore_cdprc --no-filename "^\[\.status\]:" \
+            STATUS=$( (rg "${RG_OPTIONS[@]}" --ignore-file=.rgignore_cdprc --no-filename "^\[\.status\]:" \
                        | sort | uniq -c
                        printf "%7d %s" "${WITHOUT_STATUS}" "[]: --NO-STATUS--") \
                       | fzf --reverse --select-1 --exact \
@@ -148,7 +154,7 @@ edit_by_status() {
             while true; do
                 TMPFILE=$( mktemp tmp.XXXXXXXX )
                 if [ "${VALUE}" == " --NO-STATUS--" ] ; then
-                    mapfile -t FILES < <(rg --type=markdown --no-ignore-parent --ignore-file=.rgignore_cdprc --files-without-match "^\[\.status\]:" \
+                    mapfile -t FILES < <(rg "${RG_OPTIONS[@]}" --ignore-file=.rgignore_cdprc --files-without-match "^\[\.status\]:" \
                                          | sort | tee "${TMPFILE}" \
                                          | fzf --reverse --exact --multi --bind alt-a:select-all,alt-d:deselect-all \
                                                --bind="load:pos($FZFPOS)" \
@@ -160,7 +166,7 @@ edit_by_status() {
                     # Otherwise the LFs aren't interpreted correctly by the editor.
                     # But shellcheck complained with SC2207...  https://www.shellcheck.net/wiki/SC2207
                     # And so it is now:
-                    mapfile -t FILES < <(rg --type=markdown --no-ignore-parent --ignore-file=.rgignore_cdprc --files-with-matches "^\[\.status\]:${VALUE}$"\
+                    mapfile -t FILES < <(rg "${RG_OPTIONS[@]}" --ignore-file=.rgignore_cdprc --files-with-matches "^\[\.status\]:${VALUE}$"\
                                          | sort | tee "${TMPFILE}" \
                                          | fzf --reverse --exact --multi --bind alt-a:select-all,alt-d:deselect-all \
                                                --bind="load:pos($FZFPOS)" \

--- a/.cdprc
+++ b/.cdprc
@@ -46,10 +46,11 @@ fi
 
 unset FZFPOS
 
+RG="rg --type=markdown --no-ignore-parent"
 # Since arrays are not exportable(!?) as required for __list_files_with_status
 # a normal variable is used for that:
-unset RG
-export RG="rg --type=markdown --no-ignore-parent"
+unset RG_IGN
+export RG_IGN="${RG} --ignore-file=.rgignore_cdprc"
 
 FZF=(fzf --reverse --exact)
 # shellcheck disable=2054
@@ -63,8 +64,8 @@ edit_translate_by_status() {
             TMPFILE=$( mktemp tmp.XXXXXXXX )
             FILE=$(cd de/src || exit
                    # shellcheck disable=2086  # to get the RG_OPTION word-splitted
-                   ${RG} --files-with-matches "$1" \
-                   | sort | tee "../../${TMPFILE}" \
+                   ${RG} --files-with-matches "$1" | sort \
+                   | tee "../../${TMPFILE}" \
                    | "${FZF[@]}" \
                         --header="$FZF_HEADER" \
                         --bind="load:pos($FZFPOS)" \
@@ -83,13 +84,11 @@ edit_translate_by_status() {
     else
         (cd de/src || exit
          # shellcheck disable=2086  # to get the RG_OPTION word-splitted
-         ${RG} --files-with-matches "$1" \
-         | sort)
+         ${RG} --files-with-matches "$1" | sort)
         read -r -p "Continue? ENTER, or Ctrl-C to cancel: " inp
         for FILE in $(cd de/src || exit
                       # shellcheck disable=2086  # to get the RG_OPTION word-splitted
-                      ${RG} --files-with-matches "$1" \
-                      | sort)
+                      ${RG} --files-with-matches "$1" | sort)
         do
             ${EDIT_IN_SPLIT_WINDOWS} {de,en}/src/"$FILE"
             echo ""
@@ -136,10 +135,10 @@ __list_files_with_status() {
     V=$(__get_escaped_status "$1" )
     if [ "${V}" == " --NO-STATUS--" ] ; then
         # shellcheck disable=2086  # to get the RG_OPTION word-splitted
-        ${RG} --ignore-file=.rgignore_cdprc --files-without-match "^\[\.status\]:" | sort
+        ${RG_IGN} --files-without-match "^\[\.status\]:" | sort
     else
         # shellcheck disable=2086  # to get the RG_OPTION word-splitted
-        ${RG} --ignore-file=.rgignore_cdprc --files-with-matches  "^\[\.status\]:${V}$" | sort
+        ${RG_IGN} --files-with-matches  "^\[\.status\]:${V}$" | sort
     fi
 }
 
@@ -153,10 +152,10 @@ edit_by_status() {
             FZF_HEADER=">> Please select status and press ENTER to list and edit corresponding files. (ESC to cancel.) <<"
             shopt -s extglob               # disabled by default
             # shellcheck disable=2086  # to get the RG_OPTION word-splitted
-            WITHOUT_STATUS=$(${RG} --ignore-file=.rgignore_cdprc --files-without-match "^\[\.status\]:" | wc -l)
+            WITHOUT_STATUS=$(${RG_IGN} --files-without-match "^\[\.status\]:" | wc -l)
             # shellcheck disable=2016,2086  # Expressions don't expand in single quotes, use double quotes for that.
             # Because that string is passed to fzf's preview option!
-            STATUS=$( (${RG} --ignore-file=.rgignore_cdprc --no-filename "^\[\.status\]:" \
+            STATUS=$( (${RG_IGN} --no-filename "^\[\.status\]:" \
                        | sort | uniq -c
                        printf "%7d %s" "${WITHOUT_STATUS}" "[]: --NO-STATUS--") \
                       | "${FZF[@]}" \
@@ -171,7 +170,7 @@ edit_by_status() {
                 TMPFILE=$( mktemp tmp.XXXXXXXX )
                 if [ "${VALUE}" == " --NO-STATUS--" ] ; then
                     # shellcheck disable=2086  # to get the RG_OPTION word-splitted
-                    mapfile -t FILES < <(${RG} --ignore-file=.rgignore_cdprc --files-without-match "^\[\.status\]:" \
+                    mapfile -t FILES < <(${RG_IGN} --files-without-match "^\[\.status\]:" \
                                          | sort | tee "${TMPFILE}" \
                                          | "${FZF_MULTI[@]}" \
                                               --header="${FZF_HEADER}" \
@@ -183,7 +182,7 @@ edit_by_status() {
                     # But shellcheck complained with SC2207...  https://www.shellcheck.net/wiki/SC2207
                     # And so it is now:
                     # shellcheck disable=2086  # to get the RG_OPTION word-splitted
-                    mapfile -t FILES < <(${RG} --ignore-file=.rgignore_cdprc --files-with-matches "^\[\.status\]:${VALUE}$"\
+                    mapfile -t FILES < <(${RG_IGN} --files-with-matches "^\[\.status\]:${VALUE}$"\
                                          | sort | tee "${TMPFILE}" \
                                          | "${FZF_MULTI[@]}" \
                                               --header="${FZF_HEADER}" \

--- a/de/src/TEST.txt
+++ b/de/src/TEST.txt
@@ -1,0 +1,10 @@
+
+```
+TO CHECK/TRANSLATE!
+
+  local-language-support-for-languages-other-than-de-and-en-l10n.md
+  manual-restore-of-a-tgz-backup.md
+```
+
+[.status]: translated
+[.status]: todo "Check the remaining english-only file(s)"


### PR DESCRIPTION
The multiple calls of `rg` and `fzf` have been a bit confusing/unclear due to the many used options.
That is improved now by using environment variables for common calls.